### PR TITLE
Fix LineLength and MethodLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,12 @@ Lint:
 Metrics:
   Enabled: true
 
+LineLength:
+  Max: 130
+
+MethodLength:
+  Max: 25
+
 Performance:
   Enabled: false
 
@@ -31,6 +37,3 @@ Security:
 
 Bundler:
   Enabled: false
-
-LineLength:
-  Max: 100


### PR DESCRIPTION
# 目的
rubocopのLineLengthとMethodLengthを緩くする